### PR TITLE
Requested PR Changes

### DIFF
--- a/src/model/channel/channel_id.rs
+++ b/src/model/channel/channel_id.rs
@@ -678,20 +678,12 @@ impl ChannelId {
     ///
     /// let channel_id = ChannelId::new(7);
     ///
-    /// let f1 = File::open("my_file.jpg").await?;
-    /// let f2 = File::open("my_file2.jpg").await?;
+    /// let p1 = "my_file.jpg";
+    /// let p2 = "my_file2.jpg";
+    /// let f1 = File::open(p1).await?;
+    /// let f2 = File::open(p2).await?;
     ///
-    /// let attachment1 = AttachmentType::File {
-    ///     file: &f1,
-    ///     filename: "my_file.jpg".into(),
-    /// };
-    ///
-    /// let attachment2 = AttachmentType::File {
-    ///     file: &f2,
-    ///     filename: "my_file2.jpg".into(),
-    /// };
-    ///
-    /// let files = vec![attachment1, attachment2];
+    /// let files = vec![(&f1, p1), (&f2, p2)];
     ///
     /// let builder = CreateMessage::default().content("some files");
     /// channel_id.send_files(&http, files, builder).await?;

--- a/src/model/channel/guild_channel.rs
+++ b/src/model/channel/guild_channel.rs
@@ -719,22 +719,9 @@ impl GuildChannel {
     ///                 return;
     ///             }
     ///
-    ///             let file = match File::open("./cat.png").await {
-    ///                 Ok(file) => file,
-    ///                 Err(why) => {
-    ///                     println!("Err opening file: {:?}", why);
-    ///
-    ///                     return;
-    ///                 },
-    ///             };
-    ///
-    ///             let builder = CreateMessage::default().content("here's a cat");
-    ///             let attachment = AttachmentType::File {
-    ///                 file: &file,
-    ///                 filename: "cat.png".into(),
-    ///             };
-    ///
-    ///             let _ = msg.channel_id.send_files(&context.http, vec![attachment], builder).await;
+    ///             let builder =
+    ///                 CreateMessage::default().content("here's a cat").add_file("./cat.png");
+    ///             let _ = msg.channel_id.send_message(&context.http, builder).await;
     ///         }
     ///     }
     /// }


### PR DESCRIPTION
It's easier to open a PR rather than use suggested review changes. These are my recommended changes for serenity-rs/serenity#2071. They include changing to take a `Impl Into<Cow>` when implementing `From<T>` for `AttachmentType`, and also changing `AttachmentType::Bytes.data` to a `Vec<u8>`, partly because the API change necessitates it (see my review comments on the above PR), but also because I seriously doubt how common using `&'static [u8]` would be over simply reading from a path or file, and taking a hit to API ergonomics to accommodate that isn't worth it imo.